### PR TITLE
Change footer to include Bloomberg logo

### DIFF
--- a/python-variants/custom.css
+++ b/python-variants/custom.css
@@ -355,11 +355,23 @@ body {
   font-size: 3rem;
 }
 
-.reveal .footer div#website {
+.reveal .footerleft {
+  position: absolute;
+  left: 20px;
+  bottom: 15px;
+  width: 25%;
+  height: 7%;
+  text-align: left;
+  font-size: 2.5rem;
+  color: #7f7f7f;
+}
+
+
+.reveal .footerleft div#website {
     text-decoration: underline;
 }
 
-.reveal .footer div#twitter {
+.reveal .footerleft div#twitter {
     font-weight: bold;
 }
 

--- a/python-variants/custom_template.tpl
+++ b/python-variants/custom_template.tpl
@@ -168,9 +168,12 @@ a.anchor-link {
 <div class="slides">
 {{ super() }}
 </div>
-<div class="footer">
+<div class="footerleft">
 <div id="twitter">@pganssle</div>
 <div id="website">https://ganssle.io</div>
+</div>
+<div class="footer">
+<img src='images/bloomberg-logo-alpha.svg'>
 </div>
 </div>
 {% block post_slides %}


### PR DESCRIPTION
Adds the Bloomberg logo and moves my name/twitter to the left.

I may want to change this so that in the future all talks generate two versions - one with the Bloomberg logo and one without, but for now I'll just keep the BBG logo in there.

Also, on some displays, there's some overlap between the text and the *@pganssle* stuff in the bottom left. That may need tweaking (or outputs needs an explicitly white background so that it is just an overlay.